### PR TITLE
added general perm

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -9,6 +9,7 @@ requires:
 
 page:
     title: 'translate:title'
+    perm: slice_ui[]
     pjax: true
     icon: rex-icon rex-icon-copy
     subpages:


### PR DESCRIPTION
Allgemeines Recht für das Addon. So wird es für einzelne Rollen auch nicht mehr angezeigt - zumindest besteht die Möglichkeit dazu.